### PR TITLE
Replace `setTimeout` with `requestAnimationFrame`

### DIFF
--- a/Monkeydo.mjs
+++ b/Monkeydo.mjs
@@ -37,11 +37,7 @@ export default class Monkeydo extends MonkeyMaster {
 
 	async play(manifest = null) {
 		if(!this.ready && !manifest) throw new Error("Can not start playback without a manifest");
-		if(manifest) {
-			const load = this.load(manifest)
-			load.then(() => this.start());
-			return;
-		}
+		if(manifest) await this.load(manifest);
 		return await this.start();
 	}
 }

--- a/monkey/Monkey.js
+++ b/monkey/Monkey.js
@@ -9,7 +9,7 @@ class Monkey {
 		this.tasks = {
 			tasks: [],
 			length: 0,
-			target: 0,
+			_target: 0,
 			_i: 0,
 			set manifest(manifest) {
 				this.tasks = manifest;
@@ -18,23 +18,35 @@ class Monkey {
 			get task() {
 				return this.tasks[this._i];
 			},
-			step: () => {
-				this.tasks._i++;
-				const nextTask = this.tasks.task;
-				this.tasks.target = performance.now() + nextTask[0];
+			get target() {
+				return this._target;
 			}
 		}
 	}
 
+	// Advance to the next task or loop
+	next() {
+		// Reset index and loop if out of tasks
+		if(this.tasks._i >= this.tasks.length) {
+			this.tasks._i = -1;
+			if(this.flags[1] === 255) return; // Loop forever
+			this.flags[2] -= 1;
+		}
+		
+		this.tasks._i++;
+		const nextTask = this.tasks.task;
+		this.tasks._target = performance.now() + nextTask[0];
+	}
+
 	// Main event loop, runs on every frame
 	tick() {
-		if(this === undefined) return false;
+		if(this === undefined) return;
 		if(this.flags[0] === 0 || this.flags[2] === 0) return this.abort();
 		
 		const frame = Math.min(performance.now(),this.tasks.target);
 		if(frame == this.tasks.target) {
 			postMessage(["TASK",this.tasks.task]);
-			this.tasks.step();
+			this.next();
 		}
 		
 		requestAnimationFrame(this.tick.bind(this));

--- a/monkey/Monkey.js
+++ b/monkey/Monkey.js
@@ -17,32 +17,31 @@ class Monkey {
 
 	// Task scheduler
 	next() {
-		if(this.flags[0] === 0 || this.flags[2] === 0) return this.abort();
-		const task = this.tasks[this.i];
+		const start = performance.now();
+		const self = this;
+		let task = null;
 
 		// Run task after delay
-		this.queue.thisTask = setTimeout(() => {
-			// Dispatch task to main thread
+		function frame(time) {
+			if(self.flags[0] === 0 || self.flags[2] === 0) return self.abort();
 			postMessage(["TASK",task]);
-			this.i++;
-		},task[0]);
-
-		// Loop until flag is 0 or infinite if 255
-		if(this.i === this.tasksLength) {
-			this.i = -1;
-			if(this.flags[1] < 255) this.flags[2]--;
+			self.i++;
+			scheduleFrame(time);
 		}
 
 		// Queue the next task
-		this.queue.nextTask = setTimeout(() => this.next(),task[0]);
+		function scheduleFrame(time) {
+			task = self.tasks[self.i];
+			//const elapsed = Math.round(performance.now() - start);
+			const wait = task[0] + start;
+			setTimeout(() => requestAnimationFrame(frame),wait);
+		}
+		
+		scheduleFrame(start);
 	}
 
 	abort() {
 		this.flags[2] = 0; // Playing: false
-		clearTimeout(this.queue.thisTask);
-		clearTimeout(this.queue.nextTask);
-		this.queue.thisTask = null;
-		this.queue.nextTask = null;
 	}
 
 	// Set or get a runtime flag

--- a/monkey/Monkey.js
+++ b/monkey/Monkey.js
@@ -22,18 +22,19 @@ class Monkey {
 		let task = null;
 
 		// Run task after delay
-		function frame(time) {
+		function frame() {
 			if(self.flags[0] === 0 || self.flags[2] === 0) return self.abort();
 			postMessage(["TASK",task]);
 			self.i++;
-			scheduleFrame(time);
+			scheduleFrame();
 		}
 
 		// Queue the next task
-		function scheduleFrame(time) {
+		function scheduleFrame() {
 			task = self.tasks[self.i];
 			//const elapsed = Math.round(performance.now() - start);
 			const wait = task[0] + start;
+			console.log(wait);
 			setTimeout(() => requestAnimationFrame(frame),wait);
 		}
 		

--- a/monkey/MonkeyMaster.mjs
+++ b/monkey/MonkeyMaster.mjs
@@ -47,11 +47,12 @@ export default class MonkeyMaster {
 		const Monkey = Comlink.wrap(worker);
 		this.comlink = await new Monkey();
 
-		// Wait for comlink to initialize proxy and send queued flags
+		// Wait for comlink to spin up
 		return await new Promise((resolve,reject) => {
-			if(!this.comlink) reject("Failed to open proxy to worker");
+			if(!this.comlink) reject("Failed to establish Comlink with worker");
 
 			this.ready = true;
+			// Send queued flags when worker is ready
 			this.queue.sendAllFlags();
 			resolve();
 		});
@@ -132,6 +133,6 @@ export default class MonkeyMaster {
 
 		if(playing > 0) return;
 		await this.setFlag("playing",loop);
-		return await this.comlink.next();
+		return await this.comlink.tick();
 	}
 }


### PR DESCRIPTION
Monkeydo relies on the highly volatile `setTimeout()` to chain scheduled tasks. `setTimeout()` is both susceptible to unannounced [thread sleeping](https://stackoverflow.com/questions/10739835/are-there-any-standards-for-mobile-device-web-browsers-in-terms-of-thread-sleepi/10740558#10740558) and also [time drift](https://stackoverflow.com/questions/985670/will-setinterval-drift). I have therefore replaced it with the generally more stable and consistent [`window.requestAnimationFrame()`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame).

This is a refactor and does not change the upstream developer-facing API.

`next()` has been renamed to `tick()` and contains the whole event scheduler now.
Any custom implementation calling `next()` will therefore stop working.